### PR TITLE
Add KernelArg impl for u32 and f64.

### DIFF
--- a/hl.rs
+++ b/hl.rs
@@ -457,6 +457,8 @@ macro_rules! scalar_kernel_arg (
 
 scalar_kernel_arg!(int)
 scalar_kernel_arg!(uint)
+scalar_kernel_arg!(u32)
+scalar_kernel_arg!(f64)
 
 pub fn set_kernel_arg<T: KernelArg>(kernel: & Kernel,
                                     position: cl_uint,


### PR DESCRIPTION
This adds KernelArg implementations for u32 and f64.
Adding other types could also be useful in the future.
