### PR TITLE
Improve Vector reusability.

### DIFF
--- a/hl.rs
+++ b/hl.rs
@@ -117,7 +117,7 @@ impl Device {
                 ptr::null());
             check(status, "Could not get device name");
             
-            str::raw::from_c_str(p)
+            str::raw::from_c_str(p as *i8)
         }
     } }
 }
@@ -704,7 +704,7 @@ impl KernelIndex for (uint, uint)
 #[cfg(test)]
 mod test {
     use hl::*;
-    use vector::*;
+    use vector::Vector;
     use std::io;
     
     macro_rules! expect (

--- a/vector.rs
+++ b/vector.rs
@@ -217,7 +217,7 @@ mod test {
         let ctx = create_compute_context();
 
         let x = ~[1, 2, 3, 4, 5];
-        let gx = Unique::from_vec(ctx, copy x);
+        let gx = Unique::from_vec(ctx, x.clone());
         let y = gx.to_vec();
         expect!(y, x);
     }


### PR DESCRIPTION
Add methods to re-use the same Vector multiple times. This avoids repetitive reallocation of opencl buffers by the user. The two methods are named `rewrite` and `to_existing_vec` to write/read to/from an opencl vector without allocations.
