### PR TITLE
Update to last Rust api.

### DIFF
--- a/hl.rs
+++ b/hl.rs
@@ -58,7 +58,7 @@ impl Platform {
 
       let name = " ".repeat(size as uint);
 
-      do str::as_buf(name) |p, len| {
+      do name.as_imm_buf |p, len| {
         clGetPlatformInfo(self.id,
                           CL_PLATFORM_NAME,
                           len as libc::size_t,
@@ -278,7 +278,7 @@ pub fn create_program_with_binary(ctx: & Context, device: Device,
             result::Ok(binary) => binary,
             Err(e)             => fail!(fmt!("%?", e))
         };
-        let program = do str::as_c_str(binary) |kernel_binary| {
+        let program = do binary.as_c_str |kernel_binary| {
             clCreateProgramWithBinary(ctx.ctx, 1, ptr::to_unsafe_ptr(&device.id), 
                                       ptr::to_unsafe_ptr(&(binary.len() + 1)) as *libc::size_t, 
                                       ptr::to_unsafe_ptr(&kernel_binary) as **libc::c_uchar,
@@ -546,7 +546,7 @@ impl ComputeContext
   {
     unsafe
     {
-      do str::as_c_str(src) |src| {
+      do src.as_c_str |src| {
         let status = CL_SUCCESS as cl_int;
         let program = clCreateProgramWithSource(
           self.ctx.ctx,
@@ -562,7 +562,7 @@ impl ComputeContext
   }
 
   pub fn create_program_from_binary(@self, bin: &str) -> Program {
-        do str::as_c_str(bin) |src| {
+        do bin.as_c_str |src| {
             let status = CL_SUCCESS as cl_int;
             let len = bin.len() as libc::size_t;
             let program = unsafe {

--- a/test.rs
+++ b/test.rs
@@ -6,7 +6,6 @@ use std::io;
 use std::sys;
 use std::libc;
 use std::vec;
-use std::str;
 use std::cast;
 
 fn main()
@@ -96,7 +95,7 @@ fn main()
                          ptr::null());
 
     // Create a program from the kernel and build it
-    do str::as_buf(ker) |bytes, len|
+    do ker.as_imm_buf |bytes, len|
     {
       let prog = clCreateProgramWithSource(ctx,
                                            1,
@@ -115,7 +114,7 @@ fn main()
       { io::println(fmt!("Unable to build program [%?].", r)); }
 
       // Create the OpenCL kernel
-      do str::as_buf("vector_add") |bytes, _|
+      do "vector_add".as_imm_buf() |bytes, _|
       {
         let kernel = clCreateKernel(prog, bytes as *libc::c_char, ptr::to_unsafe_ptr(&r));
         if r != CL_SUCCESS as cl_int


### PR DESCRIPTION
`as_c_str` is now a method.
`as_buf` is replaced by the method `as_imm_buf`.
