### PR TITLE
add support for N dimensional data workgroup sizes to high level API

### DIFF
--- a/hl.rs
+++ b/hl.rs
@@ -532,17 +532,17 @@ pub fn set_kernel_arg<T: KernelArg>(kernel: & Kernel,
 }
 
 #[fixed_stack_segment] #[inline(never)]
-pub fn enqueue_nd_range_kernel(cqueue: & CommandQueue, kernel: & Kernel, work_dim: cl_uint,
-                               _global_work_offset: int, global_work_size: &[int],
-                               local_work_size: &[int])
+pub fn enqueue_nd_range_kernel<I: KernelIndex>(cqueue: & CommandQueue, kernel: & Kernel,
+                               _global_work_offset: int, global_work_size: I,
+                               local_work_size: I)
 {
   unsafe
     {
-      let ret = clEnqueueNDRangeKernel(cqueue.cqueue, kernel.kernel, work_dim,
+      let ret = clEnqueueNDRangeKernel(cqueue.cqueue, kernel.kernel, KernelIndex::num_dimensions(None::<I>),
                                        // ptr::to_unsafe_ptr(&global_work_offset) as *libc::size_t,
                                        ptr::null(),
-                                       vec::raw::to_ptr(global_work_size) as *libc::size_t,
-                                       vec::raw::to_ptr(local_work_size) as *libc::size_t,
+                                       global_work_size.get_ptr(),
+                                       local_work_size.get_ptr(),
                                        0, ptr::null(), ptr::null());
       check(ret, "Failed to enqueue nd range kernel!");
   }
@@ -866,7 +866,7 @@ mod test {
         enqueue_nd_range_kernel(
             &ctx.borrow().q,
             &k,
-            1, 0, 1, 1);
+            0, (1), (1));
 
         let v = v.to_vec();
 
@@ -892,7 +892,7 @@ mod test {
         enqueue_nd_range_kernel(
             &ctx.borrow().q,
             &k,
-            1, 0, 1, 1);
+            0, (1), (1));
       
         let v = v.to_vec();
 

--- a/test.rs
+++ b/test.rs
@@ -37,7 +37,7 @@ fn main()
 	kernel.set_arg(1, &B);
 	kernel.set_arg(2, &C);
 
-	OpenCL::hl::enqueue_nd_range_kernel(&ctx.borrow().q, &kernel, 1, 0, [8], [8]);
+	OpenCL::hl::enqueue_nd_range_kernel(&ctx.borrow().q, &kernel, 0, (8), (8));
 
 	let mut vec_c: ~[int];
 	unsafe {


### PR DESCRIPTION
Pretty much what it sounds. Now the hl API takes a tuple of workgroup sizes and automatically populates the work dimension field, using the KernelIndex trait.
