### PR TITLE
Not sure how this even compiled. Iff move is used out_event cannot be se...

### DIFF
--- a/src/hl.rs
+++ b/src/hl.rs
@@ -453,7 +453,7 @@ impl CommandQueue
         let mut out_event = None;
         unsafe {
             event.as_event_list(|evt, evt_len| {
-                write.write(move |&mut : offset, p, len| {
+                write.write(|&mut : offset, p, len| {
                     let mut e: cl_event = ptr::null_mut();
                     let err = clEnqueueWriteBuffer(self.cqueue,
                                                    mem.id(),


### PR DESCRIPTION
...t by the closure.