### PR TITLE
Fix String impl for CLStatus.

### DIFF
--- a/src/cl.rs
+++ b/src/cl.rs
@@ -134,7 +134,7 @@ pub enum CLStatus {
 
 impl fmt::String for CLStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
`{}` uses `String` now, so this function recursed until stack overflow.