### PR TITLE
s/deriving/derive and remove #[deriving(Sync)].

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -59,10 +59,10 @@ macro_rules! cl_extension_loader {
 // Whatever functions we're calling aren't necessarily thread-safe, but since this is a low-level
 // interface we'll let the callers worry about that
 macro_rules! ext_struct_def {
-    () => (#[deriving(Copy, Sync)] pub struct Functions;);
+    () => (#[derive(Copy)] pub struct Functions;);
     ($($function:ident, ($($arg:ident, $arg_type:ty),+) $ret:ty)+) =>
     (
-        #[deriving(Copy, Sync)]
+        #[derive(Copy)]
         pub struct Functions {
             $(pub $function: (extern fn ($($arg : $arg_type),+) -> $ret)),+
         }


### PR DESCRIPTION
Fixes build for me on latest `rustc`, but the examples are still broken.