### PR TITLE
Multiple-device support for high-level api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ name = "demo_multidevice"
 path = "examples/demo_multidevice/main.rs"
 
 [dependencies]
-log = "^0.2.4"
+log = "<0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,9 @@ path = "examples/demo/main.rs"
 name = "platform"
 path = "examples/platform/main.rs"
 
+[[example]]
+name = "demo_multidevice"
+path = "examples/demo_multidevice/main.rs"
+
 [dependencies]
 log = "^0.2.4"

--- a/examples/demo_multidevice/demo.ocl
+++ b/examples/demo_multidevice/demo.ocl
@@ -1,0 +1,4 @@
+__kernel void vector_add(__global const long *A, __global const long *B, __global long *C) {
+	int i = get_global_id(0);
+	C[i] = A[i] + B[i];
+}

--- a/examples/demo_multidevice/main.rs
+++ b/examples/demo_multidevice/main.rs
@@ -20,7 +20,7 @@ fn main()
         .map(|d| ctx.create_command_queue(d)).collect();
 
     for (device, queue) in devices.iter().zip(queues.iter()) {
-        println!("{}", device.name());
+        println!("{}", queue.device().name());
 
         let a: CLBuffer<isize> = ctx.create_buffer(vec_a.len(), opencl::cl::CL_MEM_READ_ONLY);
         let b: CLBuffer<isize> = ctx.create_buffer(vec_a.len(), opencl::cl::CL_MEM_READ_ONLY);

--- a/examples/demo_multidevice/main.rs
+++ b/examples/demo_multidevice/main.rs
@@ -1,0 +1,68 @@
+#![feature(collections)]
+
+extern crate opencl;
+
+use opencl::mem::CLBuffer;
+use std::fmt;
+
+fn main()
+{
+    let ker = include_str!("demo.ocl");
+    println!("ker {}", ker);
+
+    let vec_a = vec![0isize, 1, 2, -3, 4, 5, 6, 7];
+    let vec_b = vec![-7isize, -6, 5, -4, 0, -1, 2, 3];
+
+    let ref platform = opencl::hl::get_platforms()[0];
+    let devices = platform.get_devices();
+    let ctx = opencl::hl::Context::create_context(&devices[..]);
+    let queues: Vec<opencl::hl::CommandQueue> = devices.iter()
+        .map(|d| ctx.create_command_queue(d)).collect();
+
+    for (device, queue) in devices.iter().zip(queues.iter()) {
+        println!("{}", device.name());
+
+        let a: CLBuffer<isize> = ctx.create_buffer(vec_a.len(), opencl::cl::CL_MEM_READ_ONLY);
+        let b: CLBuffer<isize> = ctx.create_buffer(vec_a.len(), opencl::cl::CL_MEM_READ_ONLY);
+        let c: CLBuffer<isize> = ctx.create_buffer(vec_a.len(), opencl::cl::CL_MEM_WRITE_ONLY);
+
+        queue.write(&a, &&vec_a[..], ());
+        queue.write(&b, &&vec_b[..], ());
+
+        let program = ctx.create_program_from_source(ker);
+        program.build(&device).ok().expect("Couldn't build program.");
+
+
+        let kernel = program.create_kernel("vector_add");
+
+        kernel.set_arg(0, &a);
+        kernel.set_arg(1, &b);
+        kernel.set_arg(2, &c);
+
+        let event = queue.enqueue_async_kernel(&kernel, vec_a.len(), None, ());
+
+        let vec_c: Vec<isize> = queue.get(&c, &event);
+
+        println!("  {}", string_from_slice(&vec_a[..]));
+        println!("+ {}", string_from_slice(&vec_b[..]));
+        println!("= {}", string_from_slice(&vec_c[..]));
+    }
+}
+
+fn string_from_slice<T: fmt::Display>(slice: &[T]) -> String {
+    let mut st = String::from_str("[");
+    let mut first = true;
+
+    for i in slice.iter() {
+        if !first {
+            st.push_str(", ");
+        }
+        else {
+            first = false;
+        }
+        st.push_str(&*i.to_string())
+    }
+
+    st.push_str("]");
+    return st
+}

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -429,6 +429,25 @@ unsafe impl Send for CommandQueue {}
 
 impl CommandQueue
 {
+    pub fn device(&self) -> Device
+    {
+        unsafe
+        {
+            let mut size = 0 as libc::size_t;
+            let mut device_id : cl_device_id = ptr::null_mut();
+
+            let status = clGetCommandQueueInfo(
+                self.cqueue,
+                CL_QUEUE_DEVICE,
+                mem::size_of::<cl_device_id>() as u64,
+                mem::transmute(&mut device_id),
+                &mut size as *mut libc::size_t);
+            check(status, "Could not get device from command queue");
+
+            Device{ id: device_id }
+        }
+    }
+
     //synchronous
     pub fn enqueue_kernel<I: KernelIndex, E: EventList>(&self, k: &Kernel, global: I, local: Option<I>, wait_on: E)
         -> Event

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -362,13 +362,15 @@ impl Context {
         {
             let src: Vec<*const libc::c_char> = srcs.iter()
                 .map(|s| CString::new(*s).unwrap().as_ptr()).collect();
+            let lengths: Vec<libc::size_t> = srcs.iter()
+                .map(|s| s.len() as libc::size_t).collect();
 
             let mut status = CL_SUCCESS as cl_int;
             let program = clCreateProgramWithSource(
                 self.ctx,
                 srcs.len() as u32,
                 src.as_ptr(),
-                ptr::null(),
+                lengths.as_ptr(),
                 (&mut status));
             check(status, "Could not create program");
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -353,15 +353,21 @@ impl Context {
 
     pub fn create_program_from_source(&self, src: &str) -> Program
     {
+        self.create_program_from_sources(&[src])
+    }
+
+    pub fn create_program_from_sources(&self, srcs: &[&str]) -> Program
+    {
         unsafe
         {
-            let src = CString::new(src).unwrap();
+            let src: Vec<*const libc::c_char> = srcs.iter()
+                .map(|s| CString::new(*s).unwrap().as_ptr()).collect();
 
             let mut status = CL_SUCCESS as cl_int;
             let program = clCreateProgramWithSource(
                 self.ctx,
-                1,
-                &src.as_ptr(),
+                srcs.len() as u32,
+                src.as_ptr(),
                 ptr::null(),
                 (&mut status));
             check(status, "Could not create program");

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -280,6 +280,24 @@ unsafe impl Sync for Context {}
 unsafe impl Send for Context {}
 
 impl Context {
+    pub fn create_context(devices: &[Device]) -> Context
+    {
+        unsafe
+        {
+            let mut errcode = 0;
+
+            let ctx = clCreateContext(ptr::null(),
+                                    devices.len() as u32,
+                                    mem::transmute(&devices[0]),
+                                    mem::transmute(ptr::null::<fn()>()),
+                                    ptr::null_mut(),
+                                    (&mut errcode));
+            check(errcode, "Failed to create contexts!");
+
+            Context { ctx: ctx }
+        }
+    }
+
     pub fn create_buffer<T>(&self, size: usize, flags: cl_mem_flags) -> CLBuffer<T>
     {
         unsafe {

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -360,14 +360,12 @@ impl Context {
     {
         unsafe
         {
-            let src: Vec<*const libc::c_char> = srcs.iter()
-                .map(|s| CString::new(*s).unwrap().as_ptr()).collect();
+            let c_strs: Vec<CString> = srcs.iter()
+                .map(|s| CString::new(*s).unwrap()).collect();
+            let src: Vec<*const libc::c_char> = c_strs.iter()
+                .map(|s| s.as_ptr()).collect();
             let lengths: Vec<libc::size_t> = srcs.iter()
                 .map(|s| s.len() as libc::size_t).collect();
-
-            for l in lengths.iter() {
-                println!("{}", l);
-            }
 
             let mut status = CL_SUCCESS as cl_int;
             let program = clCreateProgramWithSource(

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -618,7 +618,7 @@ impl CommandQueue
                                                    evt,
                                                    &mut e);
                     out_event = Some(e);
-                    check(err, "Failed to write buffer");
+                    check(err, "Failed to read buffer");
                 })
             })
         }

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -864,12 +864,16 @@ impl<'r> EventList for &'r [Event] {
     fn as_event_list<T, F>(&self, f: F) -> T
         where F: FnOnce(*const cl_event, cl_uint) -> T
     {
-        let mut vec: Vec<cl_event> = Vec::with_capacity(self.len());
-        for item in self.iter(){
-            vec.push(item.event);
-        }
+        if self.len() == 0 {
+            f(ptr::null(), 0)
+        } else {
+            let mut vec: Vec<cl_event> = Vec::with_capacity(self.len());
+            for item in self.iter(){
+                vec.push(item.event);
+            }
 
-        f(vec.as_ptr(), vec.len() as cl_uint)
+            f(vec.as_ptr(), vec.len() as cl_uint)
+        }
     }
 }
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -365,6 +365,10 @@ impl Context {
             let lengths: Vec<libc::size_t> = srcs.iter()
                 .map(|s| s.len() as libc::size_t).collect();
 
+            for l in lengths.iter() {
+                println!("{}", l);
+            }
+
             let mut status = CL_SUCCESS as cl_int;
             let program = clCreateProgramWithSource(
                 self.ctx,


### PR DESCRIPTION
Add `hl::Context::create_context(&[Device])`, which creates a context using all the given devices.  I wasn't sure what to name it (`new`?).

The new `create_context` has the same, pretty basic error handling as `Device::create_context()`.