### PR TITLE
Works on 32bit arch too now

### DIFF
--- a/src/hl.rs
+++ b/src/hl.rs
@@ -426,7 +426,7 @@ impl CommandQueue
                     ptr::null(),
                     global.get_ptr(),
                     match local {
-                        Some(ref l) => l.get_ptr() as *const u64,
+                        Some(ref l) => l.get_ptr() as *const libc::size_t,
                         None => ptr::null()
                     },
                     event_list_length,
@@ -455,7 +455,7 @@ impl CommandQueue
                     ptr::null(),
                     global.get_ptr(),
                     match local {
-                        Some(ref l) => l.get_ptr() as *const u64,
+                        Some(ref l) => l.get_ptr() as *const libc::size_t,
                         None => ptr::null()
                     },
                     event_list_length,

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -28,7 +28,7 @@ pub trait Buffer<T> {
             let err = clGetMemObjectInfo(self.id(),
                                          CL_MEM_SIZE,
                                          mem::size_of::<size_t>() as size_t,
-                                         (&mut size as *mut u64) as *mut c_void,
+                                         (&mut size as *mut size_t) as *mut c_void,
                                          ptr::null_mut());
 
             check(err, "Failed to read memory size");


### PR DESCRIPTION
I just changed a few casts to `*const libc::size_t` instead of `*const u64`. Now it builds an runs fine on my 32bit ubuntu :)