### PR TITLE
Add restriction to trait KernelIndex to ensure that the trait Sizes i…

### DIFF
--- a/src/hl.rs
+++ b/src/hl.rs
@@ -838,7 +838,7 @@ impl EventList for () {
 
 pub trait KernelIndex
 {
-    fn num_dimensions(dummy_self: Option<Self>) -> cl_uint;
+    fn num_dimensions(dummy_self: Option<Self>) -> cl_uint where Self: Sized;
     fn get_ptr(&self) -> *const libc::size_t;
 }
 


### PR DESCRIPTION
…s implemented for Self. Fixing issue #71 

This commit *should* fix issue #71, by forcing Self to implement the "Sized" trait. I'm fairly new to Rust, so if there's a better approach, please let me know!