### PR TITLE
Fix issue #78 with multiple imports of std, and remove raw_pointer_deriving lint

### DIFF
--- a/examples/platform/main.rs
+++ b/examples/platform/main.rs
@@ -16,7 +16,8 @@ fn main() {
             println!("   Profile: {}", device.profile());
             println!("   Compute Units: {}", device.compute_units());
             println!("   Global Memory Size: {} MB", device.global_mem_size() / (1024 * 1024));
-            println!("   Local Memory Size: {} MB", device.global_mem_size() / (1024 * 1024));
+            println!("   Local Memory Size: {} MB", device.local_mem_size() / (1024 * 1024));
+            println!("   Max Alloc Size: {} MB", device.max_mem_alloc_size() / (1024 * 1024));
         }
     }
 }

--- a/examples/platform/main.rs
+++ b/examples/platform/main.rs
@@ -15,6 +15,8 @@ fn main() {
             println!("   Type: {}", device.device_type());
             println!("   Profile: {}", device.profile());
             println!("   Compute Units: {}", device.compute_units());
+            println!("   Global Memory Size: {} MB", device.global_mem_size() / (1024 * 1024));
+            println!("   Local Memory Size: {} MB", device.global_mem_size() / (1024 * 1024));
         }
     }
 }

--- a/src/cl.rs
+++ b/src/cl.rs
@@ -1,7 +1,5 @@
 #![allow(non_camel_case_types, dead_code)]
 
-extern crate std;
-
 use libc;
 use std::fmt;
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,6 +1,5 @@
 #![allow(unused,
          unused_attributes,
-         raw_pointer_derive,
          non_camel_case_types,
          non_snake_case)]
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -249,6 +249,34 @@ impl Device {
 		}
 	}
 
+    pub fn global_mem_size(&self) -> usize {
+        unsafe {
+            let mut ct: usize = 0;
+            let status = clGetDeviceInfo(
+                self.id,
+                CL_DEVICE_GLOBAL_MEM_SIZE,
+                16,
+                (&mut ct as *mut usize) as *mut libc::c_void,
+                ptr::null_mut());
+            check(status, "Could not get size of global memory.");
+            return ct;
+        }
+    }
+
+    pub fn local_mem_size(&self) -> usize {
+        unsafe {
+            let mut ct: usize = 0;
+            let status = clGetDeviceInfo(
+                self.id,
+                CL_DEVICE_LOCAL_MEM_SIZE,
+                16,
+                (&mut ct as *mut usize) as *mut libc::c_void,
+                ptr::null_mut());
+            check(status, "Could not get size of local memory.");
+            return ct;
+        }
+    }
+
 
     pub fn create_context(&self) -> Context
     {

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -692,6 +692,14 @@ impl Kernel {
     {
         set_kernel_arg(self, i as cl::cl_uint, x)
     }
+
+    pub fn alloc_local<T>(&self, i: usize, l: usize)
+    {
+        alloc_kernel_local::<T>(self, i as cl::cl_uint, 
+            l as libc::size_t)
+            // s as libc::size_t,
+
+    }
 }
 
 pub fn create_kernel(program: &Program, kernel: & str) -> Kernel
@@ -762,6 +770,18 @@ pub fn set_kernel_arg<T: KernelArg>(kernel: & Kernel,
     }
 }
 
+pub fn alloc_kernel_local<T>(kernel: &Kernel,
+                       position: cl_uint,
+                       // size: libc::size_t,
+                       length: libc::size_t){
+    unsafe
+    {
+        let tsize = mem::size_of::<T>() as libc::size_t;
+        let ret = clSetKernelArg(kernel.kernel, position,
+                tsize*length, ptr::null());
+        check(ret, "Failed to set kernel arg!");
+    }
+}
 
 pub struct Event
 {

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -277,6 +277,19 @@ impl Device {
         }
     }
 
+    pub fn max_mem_alloc_size(&self) -> usize {
+        unsafe {
+            let mut ct: usize = 0;
+            let status = clGetDeviceInfo(
+                self.id,
+                CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+                16,
+                (&mut ct as *mut usize) as *mut libc::c_void,
+                ptr::null_mut());
+            check(status, "Could not get size of local memory.");
+            return ct;
+        }
+    }
 
     pub fn create_context(&self) -> Context
     {


### PR DESCRIPTION
Firstly, opencl-rust fails to build on the latest nightly (rustc 1.6.0-nightly (a2866e387 2015-11-30)), as std is included multiple times. See issue #78 for more details. This is fixed in commit e18760f.

Secondly, the raw_pointer_derive lint has been removed in the latest nightly, leading to warnings at compile time. I've removed it for now, and it can be re-added later if necessary.