### PR TITLE
Fixes to compile with most recent rust stable, as well as added features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ path = "examples/platform/main.rs"
 [dependencies]
 log = "^0.3.1"
 libc = "^0.1.8"
+lazy_static = "0.2.1"

--- a/examples/platform/main.rs
+++ b/examples/platform/main.rs
@@ -16,7 +16,8 @@ fn main() {
             println!("   Profile: {}", device.profile());
             println!("   Compute Units: {}", device.compute_units());
             println!("   Global Memory Size: {} MB", device.global_mem_size() / (1024 * 1024));
-            println!("   Local Memory Size: {} MB", device.global_mem_size() / (1024 * 1024));
+            println!("   Local Memory Size: {} MB", device.local_mem_size() / (1024 * 1024));
+            println!("   Max Alloc Size: {} MB", device.max_mem_alloc_size() / (1024 * 1024));
         }
     }
 }

--- a/examples/platform/main.rs
+++ b/examples/platform/main.rs
@@ -15,6 +15,8 @@ fn main() {
             println!("   Type: {}", device.device_type());
             println!("   Profile: {}", device.profile());
             println!("   Compute Units: {}", device.compute_units());
+            println!("   Global Memory Size: {} MB", device.global_mem_size() / (1024 * 1024));
+            println!("   Local Memory Size: {} MB", device.global_mem_size() / (1024 * 1024));
         }
     }
 }

--- a/src/cl.rs
+++ b/src/cl.rs
@@ -1,7 +1,5 @@
 #![allow(non_camel_case_types, dead_code)]
 
-extern crate std;
-
 use libc;
 use std::fmt;
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,6 +1,5 @@
 #![allow(unused,
          unused_attributes,
-         raw_pointer_derive,
          non_camel_case_types,
          non_snake_case)]
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -249,6 +249,34 @@ impl Device {
 		}
 	}
 
+    pub fn global_mem_size(&self) -> usize {
+        unsafe {
+            let mut ct: usize = 0;
+            let status = clGetDeviceInfo(
+                self.id,
+                CL_DEVICE_GLOBAL_MEM_SIZE,
+                16,
+                (&mut ct as *mut usize) as *mut libc::c_void,
+                ptr::null_mut());
+            check(status, "Could not get size of global memory.");
+            return ct;
+        }
+    }
+
+    pub fn local_mem_size(&self) -> usize {
+        unsafe {
+            let mut ct: usize = 0;
+            let status = clGetDeviceInfo(
+                self.id,
+                CL_DEVICE_LOCAL_MEM_SIZE,
+                16,
+                (&mut ct as *mut usize) as *mut libc::c_void,
+                ptr::null_mut());
+            check(status, "Could not get size of local memory.");
+            return ct;
+        }
+    }
+
 
     pub fn create_context(&self) -> Context
     {

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -1,7 +1,5 @@
 //! A higher level API.
-
 use libc;
-use std;
 use std::ffi::CString;
 use std::iter::repeat;
 use std::marker::PhantomData;
@@ -9,6 +7,7 @@ use std::mem;
 use std::ptr;
 use std::string::String;
 use std::vec::Vec;
+use std::sync::Mutex;
 
 use cl;
 use cl::*;
@@ -21,6 +20,7 @@ use mem::{Put, Get, Write, Read, Buffer, CLBuffer};
 pub enum DeviceType {
       CPU, GPU
 }
+
 
 fn convert_device_type(device: DeviceType) -> cl_device_type {
     match device {
@@ -131,7 +131,9 @@ impl Platform {
 // This mutex is used to work around weak OpenCL implementations.
 // On some implementations concurrent calls to clGetPlatformIDs
 // will cause the implantation to return invalid status.
-static mut platforms_mutex: std::sync::StaticMutex = std::sync::MUTEX_INIT;
+lazy_static! {
+    static ref platforms_mutex : Mutex<i32> = Mutex::new(0);
+}
 
 pub fn get_platforms() -> Vec<Platform>
 {
@@ -697,8 +699,6 @@ impl Kernel {
     {
         alloc_kernel_local::<T>(self, i as cl::cl_uint, 
             l as libc::size_t)
-            // s as libc::size_t,
-
     }
 }
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -692,6 +692,14 @@ impl Kernel {
     {
         set_kernel_arg(self, i as cl::cl_uint, x)
     }
+
+    pub fn alloc_local<T>(&self, i: usize, l: usize)
+    {
+        alloc_kernel_local::<T>(self, i as cl::cl_uint, 
+            l as libc::size_t)
+            // s as libc::size_t,
+
+    }
 }
 
 pub fn create_kernel(program: &Program, kernel: & str) -> Kernel
@@ -762,6 +770,18 @@ pub fn set_kernel_arg<T: KernelArg>(kernel: & Kernel,
     }
 }
 
+pub fn alloc_kernel_local<T>(kernel: &Kernel,
+                       position: cl_uint,
+                       // size: libc::size_t,
+                       length: libc::size_t){
+    unsafe
+    {
+        let tsize = mem::size_of::<T>() as libc::size_t;
+        let ret = clSetKernelArg(kernel.kernel, position,
+                tsize*length, ptr::null());
+        check(ret, "Failed to set kernel arg!");
+    }
+}
 
 pub struct Event
 {

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -277,6 +277,19 @@ impl Device {
         }
     }
 
+    pub fn max_mem_alloc_size(&self) -> usize {
+        unsafe {
+            let mut ct: usize = 0;
+            let status = clGetDeviceInfo(
+                self.id,
+                CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+                16,
+                (&mut ct as *mut usize) as *mut libc::c_void,
+                ptr::null_mut());
+            check(status, "Could not get size of local memory.");
+            return ct;
+        }
+    }
 
     pub fn create_context(&self) -> Context
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,14 @@
 #![allow(missing_copy_implementations)]
 #![allow(non_upper_case_globals)]
 
-#![feature(static_mutex)]
-
 //! OpenCL bindings for Rust.
 
 extern crate libc;
 #[macro_use]
 extern crate log;
+
+#[macro_use]
+extern crate lazy_static;
 
 #[link(name = "OpenCL", kind = "framework")]
 #[cfg(target_os = "macos")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,3 @@
-#![feature(slice_bytes)]
-
 #[macro_use]
 extern crate log;
 
@@ -64,7 +62,7 @@ mod mem {
             unsafe {
                 let ptr = ptr as *const u8;
                 let src = slice::from_raw_parts(ptr, len);
-                slice::bytes::copy_memory(src, target);
+                target.clone_from_slice(src);
             }
         });
 
@@ -77,7 +75,7 @@ mod mem {
             unsafe {
                 let ptr = ptr as *mut u8;
                 let mut dst = slice::from_raw_parts_mut(ptr, len);
-                slice::bytes::copy_memory(src, dst);
+                dst.copy_from_slice(src);
             }
         })
     }


### PR DESCRIPTION
Note: this PR contains a variety of different bits of work over the course of several months. Apologies.

Fixes: 
- removed std crate reference
- removed `raw_pointer_derive` lint
- remove `StaticMutex` use, as it is deprecated
- remove `slice::bytes` module use, as it is deprecated

Features:
- added local memory allocation 
- added more device information queries
